### PR TITLE
🎨 Css-ify GitHub

### DIFF
--- a/source/github.css
+++ b/source/github.css
@@ -1,0 +1,19 @@
+img.rounded-2 {
+  visibility: hidden;
+}
+
+.vcard-fullname {
+  visibility: hidden;
+}
+
+img.timeline-comment-avatar {
+  visibility: hidden;
+}
+
+.discussion-item img.avatar {
+  visibility: hidden;
+}
+
+.participant-avatar img.avatar {
+  visibility: hidden;
+}

--- a/source/github.js
+++ b/source/github.js
@@ -1,12 +1,2 @@
-var result;
-
 // GitHub:
 document.title = '';
-result = document.querySelector('img.rounded-2');
-if (result) {
-  result.style.display = 'none';
-}
-result = document.querySelector('.vcard-fullname');
-if (result) {
-  result.style.display = 'none';
-}

--- a/source/manifest.json
+++ b/source/manifest.json
@@ -17,6 +17,7 @@
         "http://*.github.com/*",
         "https://*.github.com/*"
       ],
+      "css": ["github.css"],
       "js": ["github.js"]
     },
     {


### PR DESCRIPTION
* Broken off part of @chrisbodhi 's work on https://github.com/fureigh/unbias-me/pull/35

Works ⚡️-fast, I never even saw a flash of the profile picture. `visibility: hidden` allows the content to take up the same space as before. This leaves the GitHub UI intact, with white blanks where old content would have been instead of compressing that space.

Examples:
![screen shot 2017-03-11 at 3 37 41 am](https://cloud.githubusercontent.com/assets/3408480/23822958/7efbb2a0-060c-11e7-8678-28d92bc9bbf4.png)

<img width="1046" alt="screen shot 2017-03-11 at 3 42 22 am" src="https://cloud.githubusercontent.com/assets/3408480/23822989/fbf551ee-060c-11e7-8080-11f6f95953f9.png">

If this is good, I'll apply these changes to Twitter as well. Pretty stoked on this, it makes the extension usable for its original purpose without having to make yourself ignore the pictures on initial page load!
