### PR TITLE
CSS-ify Twitter

### DIFF
--- a/source/manifest.json
+++ b/source/manifest.json
@@ -31,6 +31,7 @@
         "http://*.twitter.com/*",
         "https://*.twitter.com/*"
       ],
+      "css": ["twitter.css"],
       "js": ["twitter.js"]
     }
   ]

--- a/source/twitter.css
+++ b/source/twitter.css
@@ -6,5 +6,5 @@ img.avatar.js-action-profile-avatar,
 h1.ProfileHeaderCard-name,
 .js-retweet-text b,
 img.ProfileAvatar-image {
-  display: none;
+  visibility: hidden;
 }

--- a/source/twitter.css
+++ b/source/twitter.css
@@ -1,0 +1,9 @@
+/* Twitter */
+
+.account-group strong,
+img.avatar.js-action-profile-avatar,
+.ProfileCanopy-headerBg img,
+h1.ProfileHeaderCard-name,
+img.ProfileAvatar-image {
+  display: none;
+}

--- a/source/twitter.css
+++ b/source/twitter.css
@@ -4,6 +4,7 @@
 img.avatar.js-action-profile-avatar,
 .ProfileCanopy-headerBg img,
 h1.ProfileHeaderCard-name,
+.js-retweet-text b,
 img.ProfileAvatar-image {
   display: none;
 }

--- a/source/twitter.js
+++ b/source/twitter.js
@@ -1,11 +1,3 @@
-var result;
+// Twitter
 
-document.title = '';
-result = document.querySelector('img.ProfileAvatar-image');
-if (result) {
-  result.style.display = 'none';
-}
-result = document.querySelector('h1.ProfileHeaderCard-name');
-if (result) {
-  result.style.display = 'none';
-}
+document.title = 'Twitter';


### PR DESCRIPTION
Following discussion [here](https://github.com/fureigh/unbias-me/pull/35#issuecomment-284803998) and @dawsbot's work on #37 &mdash; breaking apart my earlier work into domain-specific PRs.

So, Twitter: does this look ok? Everything except the page title is handled by CSS; there's still a lag with the JS updating the page title to just "Twitter," and since changing views [Tweets, Tweets & Replies, Media] seems to be AJAX calls, the `twitter.js` script doesn't get run each time. Open to feedback and suggestions on how else to handle that. 

_Before_

<img width="1280" alt="screen shot 2017-03-12 at 11 38 15 pm" src="https://cloud.githubusercontent.com/assets/4071697/23841705/23e43028-077d-11e7-89df-070de4f9f5cd.png">


_After_

<img width="1280" alt="screen shot 2017-03-12 at 11 37 48 pm" src="https://cloud.githubusercontent.com/assets/4071697/23841707/285324ac-077d-11e7-87cf-df8ea9a4e653.png">




